### PR TITLE
fix computations: less rounding + round with 2 digits like on ecoindex.fr website

### DIFF
--- a/script/ecoIndex.js
+++ b/script/ecoIndex.js
@@ -57,11 +57,11 @@ return "G";
 
 function computeGreenhouseGasesEmissionfromEcoIndex(ecoIndex)
 {
-	return Math.round(2 + 2 * (50 - ecoIndex) / 100, 2);
+	return (2 + 2 * (50 - ecoIndex) / 100).toFixed(2);
 }
 
 function computeWaterConsumptionfromEcoIndex(ecoIndex)
 {
-	return Math.round(3 + 3 * (50 - ecoIndex) / 100, 2);
+	return (3 + 3 * (50 - ecoIndex) / 100).toFixed(2);
 }
 

--- a/script/ecoIndex.js
+++ b/script/ecoIndex.js
@@ -31,7 +31,7 @@ const q_req= computeQuantile(quantiles_req,req);
 const q_size= computeQuantile(quantiles_size,size);
 
 
-return Math.round(100 - 5 * (3*q_dom + 2*q_req + q_size)/6);
+return 100 - 5 * (3*q_dom + 2*q_req + q_size)/6;
 }
 
 function computeQuantile(quantiles,value)
@@ -57,11 +57,11 @@ return "G";
 
 function computeGreenhouseGasesEmissionfromEcoIndex(ecoIndex)
 {
-	return (Math.round(100 * (2 + 2 * (50 - ecoIndex) / 100)) / 100);
+	return Math.round(2 + 2 * (50 - ecoIndex) / 100, 2);
 }
 
 function computeWaterConsumptionfromEcoIndex(ecoIndex)
 {
-	return (Math.round(100 * (3 + 3 * (50 - ecoIndex) / 100)) / 100);
+	return Math.round(3 + 3 * (50 - ecoIndex) / 100, 2);
 }
 

--- a/script/greenpanel.js
+++ b/script/greenpanel.js
@@ -54,7 +54,7 @@ function isOldAnalyse(startingTime) { return (startingTime < lastAnalyseStarting
 
 function computeEcoIndexMeasures(measures) {
   const rawEcoIndex = computeEcoIndex(measures.domSize, measures.nbRequest, Math.round(measures.responsesSize / 1000));
-  measures.ecoIndex = Math.round(rawEcoIndex, 2);
+  measures.ecoIndex = rawEcoIndex.toFixed(2);
   measures.waterConsumption = computeWaterConsumptionfromEcoIndex(rawEcoIndex);
   measures.greenhouseGasesEmission = computeGreenhouseGasesEmissionfromEcoIndex(rawEcoIndex);
   measures.grade = getEcoIndexGrade(rawEcoIndex);

--- a/script/greenpanel.js
+++ b/script/greenpanel.js
@@ -53,10 +53,11 @@ function handleResponseFromBackground(frameMeasures) {
 function isOldAnalyse(startingTime) { return (startingTime < lastAnalyseStartingTime) }
 
 function computeEcoIndexMeasures(measures) {
-  measures.ecoIndex = computeEcoIndex(measures.domSize, measures.nbRequest, Math.round(measures.responsesSize / 1000));
-  measures.waterConsumption = computeWaterConsumptionfromEcoIndex(measures.ecoIndex);
-  measures.greenhouseGasesEmission = computeGreenhouseGasesEmissionfromEcoIndex(measures.ecoIndex);
-  measures.grade = getEcoIndexGrade(measures.ecoIndex);
+  const rawEcoIndex = computeEcoIndex(measures.domSize, measures.nbRequest, Math.round(measures.responsesSize / 1000));
+  measures.ecoIndex = Math.round(rawEcoIndex, 2);
+  measures.waterConsumption = computeWaterConsumptionfromEcoIndex(rawEcoIndex);
+  measures.greenhouseGasesEmission = computeGreenhouseGasesEmissionfromEcoIndex(rawEcoIndex);
+  measures.grade = getEcoIndexGrade(rawEcoIndex);
 }
 
 


### PR DESCRIPTION
- delay rounding of ecoIndex value
- set precision to 2 digits like on the website ecoindex.fr (for ecoIndex, CO2 and water)

_(warning: not tested!)_