### PR TITLE
Update ecoIndex.js - EcoIndex Value not in defined Bounds (0-100)

### DIFF
--- a/script/ecoIndex.js
+++ b/script/ecoIndex.js
@@ -38,7 +38,7 @@ function computeQuantile(quantiles,value)
 {
 for (let i=1;i<quantiles.length;i++)
 	{
-	if (value<quantiles[i]) return (i + (value-quantiles[i-1])/(quantiles[i] -quantiles[i-1]));
+	if (value<quantiles[i]) return ((value-quantiles[i-1])/(quantiles[i] -quantiles[i-1]));
 	}
 return quantiles.length;
 }


### PR DESCRIPTION
Due to your function **computeQuantile** never return 0, your formula can never return a value higher than 95. I changed the return so it could actually return a 0 value, and it could be mathematically be possible to achieve an index of 100 (even if it only makes theoretically sense).
If you test it by now with the minimal logical values (1 DOM-Element, 1 Request and 1 KB), you achieve 98,5, which gives way more sense than 93.5