### PR TITLE
#Issue 34 : Ignore SVG stylesheets in the inline stylesheet count

### DIFF
--- a/script/analyseFrame.js
+++ b/script/analyseFrame.js
@@ -102,7 +102,9 @@ function getInlineStyleSheetsNumber() {
   let inlineStyleSheetsNumber = 0;
   styleSheetsArray.forEach(styleSheet => {
     try {
-      if (!styleSheet.href) inlineStyleSheetsNumber++;
+      // Ignore SVG styles in count 
+      const isSvgStyleSheet = (styleSheet.ownerNode instanceof SVGStyleElement);
+      if (!styleSheet.href && !isSvgStyleSheet) inlineStyleSheetsNumber++;
     }
     catch (err) {
       console.log("GREENIT-ANALYSIS ERROR ," + err.name + " = " + err.message);


### PR DESCRIPTION
Bonjour,

Ce commit vient corriger le comptage soumis dans l'issue https://github.com/cnumr/GreenIT-Analysis/issues/34 en se basant sur le type du parent de la feuille de style.

Cordialement,
