### PR TITLE
#58 Change old repo URL to new one in manifests and history.html

### DIFF
--- a/history.html
+++ b/history.html
@@ -92,7 +92,7 @@
 <br/>
 <div class="row">
  <div class="col-sm-12" style="text-align:right">
-<a href="https://github.com/didierfred/GreenIT-Analysis" target="_blank" rel="noopener noreferrer" data-i18n="helpLink" style="float:right">
+<a href="https://github.com/cnumr/GreenIT-Analysis" target="_blank" rel="noopener noreferrer" data-i18n="helpLink" style="float:right">
           <span class="glyphicon glyphicon-question-sign"></span>
       </a> 
  </div>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 2,
   "name": "GreenIT-Analysis",
   "version": "3.1.4",
-  "homepage_url": "https://github.com/didierfred/GreenIT-Analysis",
+  "homepage_url": "https://github.com/cnumr/GreenIT-Analysis",
   "icons" : {
     "48": "icons/logo-48.png"
   },

--- a/manifestV2.json
+++ b/manifestV2.json
@@ -3,7 +3,7 @@
   "manifest_version": 2,
   "name": "GreenIT-Analysis",
   "version": "3.1.4",
-  "homepage_url": "https://github.com/didierfred/GreenIT-Analysis",
+  "homepage_url": "https://github.com/cnumr/GreenIT-Analysis",
   "icons" : {
     "48": "icons/logo-48.png"
   },

--- a/manifestV3.json
+++ b/manifestV3.json
@@ -3,7 +3,7 @@
   "manifest_version": 3,
   "name": "GreenIT-Analysis",
   "version": "3.1.4",
-  "homepage_url": "https://github.com/didierfred/GreenIT-Analysis",
+  "homepage_url": "https://github.com/cnumr/GreenIT-Analysis",
   "icons" : {
     "48": "icons/logo-48.png"
   },


### PR DESCRIPTION
Hello,

Following issue https://github.com/cnumr/GreenIT-Analysis/issues/58 I changed the old repo URL which is 404 now to the current one (I faced the issue myself)

Kind Regards,
Baptiste