### PR TITLE
feat: ui fixes

### DIFF
--- a/GreenPanel.html
+++ b/GreenPanel.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="css/bootstrap.min.css">
 
   <style type="text/css">
+    .buttonList > .btn {
+      margin-top: .75rem;
+    }
     .grade {
       display: inline-block;
       width: 24px;
@@ -16,7 +19,7 @@
       text-align: center;
       border-radius: 50%;
       background-color: #f00;
-      font-size: 18px;
+      font-size: 1.25rem;
       line-height: 22px;
     }
 
@@ -67,7 +70,6 @@
       overflow: hidden;
       padding : 2.2pt;
       text-overflow: ellipsis;
-      font-size: 10px;
       text-align: left;
     }
 
@@ -78,8 +80,11 @@
     table {
       border-collapse: collapse;
       table-layout: fixed;
-      width: 95%;
       margin: auto;
+    }
+
+    .bestPraticesTable {
+      width: 100%;
     }
 
     .bestPracticeLink {
@@ -89,40 +94,37 @@
     .detailCommentLink {
       color: rgb(3, 3, 3);
       background-color: #F6EB15;
-
       background-color: rgb(219, 221, 223);
-      font-size: 10px;
+      font-size: 0.875rem;
       line-height: 5px;
     }
 
     .line {
-    width: 90%;
-    margin: auto;
-    color: rgba(0, 0, 0, 0);
-    line-height: 1px;
-    background-color: rgb(216, 221, 215);
-    margin-top: 1px;
-    margin-bottom: 10px;
-  }
+      margin: auto;
+      color: rgba(0, 0, 0, 0);
+      line-height: 1px;
+      background-color: rgb(216, 221, 215);
+      margin-top: 1px;
+      margin-bottom: 10px;
+    }
 
   </style>
 
 </head>
 
 <body>
-  <div style="text-align:center">
+  <div style="text-align:center; margin-inline: 0.75em;">
     <div class="container-fluid">
 
+      <div class="buttonList">
+        <button id="launchAnalyse" class="btn btn-primary" data-i18n="launchAnalyseButton"></button>
+        <button id="clearBrowserCache" class="btn btn-primary" data-i18n="clearBrowserCacheButton"></button>
+        <button id="saveAnalyse" class="btn btn-primary" data-i18n="saveAnalyseButton"></button>
+        <button id="viewHistory" class="btn btn-primary" data-i18n="historyButton"></button>
+        <a href="https://github.com/cnumr/GreenIT-Analysis" target="_blank" class="btn btn-primary" data-i18n="helpButton"></a>
+      </div>
 
-      <a href="#" id="launchAnalyse" class="btn btn-primary btn-sm" data-i18n="launchAnalyseButton"></a>
-      <a href="#" id="clearBrowserCache" class="btn btn-primary btn-sm" data-i18n="clearBrowserCacheButton"></a>
-      <a href="#" id="saveAnalyse" class="btn btn-primary btn-sm" data-i18n="saveAnalyseButton"></a>
-      <a href="#" id="viewHistory" class="btn btn-primary btn-sm" data-i18n="historyButton"></a>
-      <a href="#" id="helpButton" class="btn btn-primary btn-sm" data-i18n="helpButton"></a>
-
-      <br />
-
-      <div data-i18n="activateBestPracticeAnalysisCheckbox" style="font-size:10pt;">
+      <div data-i18n="activateBestPracticeAnalysisCheckbox">
         <input type="checkbox"  id="analyseBestPracticesCheckBox"></input>
       </div>
 
@@ -132,8 +134,8 @@
 
     <div id="ecoIndexView" hidden>
 
-      <H4> EcoIndex <span id="grade"></span>
-      </H4>
+      <h4> EcoIndex <span id="grade"></span>
+      </h4>
 
       <table class="mytable">
         <tbody>
@@ -169,9 +171,9 @@
     </div>
 
     <div id="bestPracticesView" hidden>
-      <H4 data-i18n="bestPractices"></H4>
+      <h4 data-i18n="bestPractices"></h4>
 
-      <table>
+      <table class="table table-striped table-hover bestPraticesTable">
         <tbody id="bestPracticesTable">
         </tbody>
       </table>

--- a/script/rules/ImageDownloadedNotDisplayed.js
+++ b/script/rules/ImageDownloadedNotDisplayed.js
@@ -27,7 +27,7 @@ function createImageDownloadedNotDisplayedRule() {
         check: function (measures) {
             measures.imagesResizedInBrowser.forEach(entry => {
                 if (!this.specificMeasures.imgAnalysed.has(entry.src) && this.isRevelant(entry)) { // Do not count two times the same picture
-                    this.detailComment += chrome.i18n.getMessage("rule_ImageDownloadedNotDisplayed_DetailComment", [entry.src, `${entry.naturalWidth}x${entry.naturalHeight}`]) + '<br>';
+                    this.detailComment += chrome.i18n.getMessage("rule_ImageDownloadedNotDisplayed_DetailComment", ['<a href="'+entry.src + '">'+entry.src+'</a>', `${entry.naturalWidth}x${entry.naturalHeight}`]) + '<br>';
                     this.specificMeasures.imgAnalysed.set(entry.src);
                     this.specificMeasures.imageDownloadedNotDisplayedNumber += 1;
                 }

--- a/script/ui.js
+++ b/script/ui.js
@@ -20,7 +20,6 @@ function initUI() {
   document.getElementById('clearBrowserCache').addEventListener('click', (e) => clearBrowserCache());
   document.getElementById('saveAnalyse').addEventListener('click', (e) => storeAnalysisInHistory());
   document.getElementById('viewHistory').addEventListener('click', (e) => viewHistory());
-  document.getElementById('helpButton').addEventListener('click', (e) => viewHelp());
   document.getElementById('analyseBestPracticesCheckBox').addEventListener('click', (e) => setAnalyseBestPractices());
 
   // Set best practices
@@ -57,7 +56,7 @@ function loadHTMLBestPractice(ruleId) {
   html += "</a>";
   html += "</td>";
   html += "<td style=\"width:30px\"> <img id=\"" + ruleId + "_status\" src=\"icons/A.png\"></td>";
-  html += "<td> <span id=\"" + ruleId + "_comment\"> </span> <a href=\"#\" id=\"" + ruleId + "_DetailComment\" class=\"detailCommentLink\" hidden>.....</a> </td>";
+  html += "<td> <span id=\"" + ruleId + "_comment\"> </span> <a href=\"#\" id=\"" + ruleId + "_DetailComment\" class=\"detailCommentLink\" hidden><span class=\"caret\"></span></a></td>";
 
   var newTR = document.createElement("tr");
   newTR.innerHTML = html;
@@ -157,10 +156,6 @@ function loadHistoryTab(tabs) {
   else chrome.tabs.create({ url: "history.html" });
 }
 
-
-function viewHelp() {
-  window.open("https://github.com/cnumr/GreenIT-Analysis");
-}
 
 
 function setAnalyseBestPractices() {


### PR DESCRIPTION
Quelques petits ajustements visuels pour répondre aux demandes de Raphael dans [cette issue](https://github.com/cnumr/GreenIT-Analysis/issues/88)

En résumé:
- Ajout de padding pour éviter que les boutons ne touchent la barre de menu au dessus (et entre eux lorsqu'ils passent l"un sous l'autre)
- Agrandir la taille du texte et des boutons pour une meilleure lisibilité 
- Ajout d'une classe pour que les lignes du tableau de bonnes pratiques soit "zebrée", pour améliorer la lisibilité
- Rendre plus explicite la possibilité de voir le détail des erreurs avec un bouton à la place des points de suspension.
- Rendre cliquables les liens dans le détails des erreurs (par exemple les images dans cette capture)

Aperçus:
<img width="1411" height="700" alt="Capture d’écran 2025-11-05 à 22 19 04" src="https://github.com/user-attachments/assets/251481cc-68d8-406d-a426-c505177b99b7" />
<img width="1436" height="708" alt="Capture d’écran 2025-11-05 à 22 19 24" src="https://github.com/user-attachments/assets/d35c0b13-9ff7-446e-bbca-1ad71a1a03bf" />



